### PR TITLE
feat: show participant avatars and join summary on event detail

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -83,6 +83,13 @@ export default function AppLayout() {
             title: "Profile",
           }}
         />
+        <Tabs.Screen
+          name="participants"
+          options={{
+            href: null,
+            title: "Participants",
+          }}
+        />
       </Tabs>
     </>
   );

--- a/apps/mobile/app/(app)/event/[id].tsx
+++ b/apps/mobile/app/(app)/event/[id].tsx
@@ -46,7 +46,7 @@ export default function EventDetailScreen() {
         `
         *,
         host:profiles!events_host_id_fkey(id, email, display_name),
-        event_members(user_id)
+        event_members(user_id, profile:profiles!event_members_user_id_fkey(id, email, display_name, avatar_url))
       `,
       )
       .eq("id", id)
@@ -64,6 +64,7 @@ export default function EventDetailScreen() {
         is_joined: userId
           ? data.event_members?.some((m: any) => m.user_id === userId)
           : false,
+        participants: data.event_members ?? [],
       };
       setEvent(eventWithDetails);
 
@@ -284,6 +285,25 @@ const handleChangePhoto = async () => {
           ? "1 spot left"
           : `${spotsLeft} spots left`;
 
+  const participants = event.participants ?? [];
+  const avatarStack = participants.slice(0, 5);
+
+  const buildJoinSummary = () => {
+    if (participants.length === 0) return null;
+    const getName = (p: (typeof participants)[0]) =>
+      (p.profile?.display_name || p.profile?.email?.split("@")[0] || "Someone").split(" ")[0];
+    if (participants.length === 1) return `${getName(participants[0])} joined`;
+    if (participants.length === 2)
+      return `${getName(participants[0])} and ${getName(participants[1])} joined`;
+    const others = participants.length - 1;
+    return `${getName(participants[0])}, and ${others} other${others > 1 ? "s" : ""} joined`;
+  };
+
+  const joinSummary = buildJoinSummary();
+
+  const AVATAR_SIZE = 32;
+  const AVATAR_OVERLAP = 10;
+
   return (
     <ScrollView className="flex-1 bg-osu-light">
       <View className="p-4">
@@ -352,6 +372,75 @@ const handleChangePhoto = async () => {
             </Text>
             <Text className="text-osu-dark">{scarcityCopy}</Text>
           </View>
+
+          {participants.length > 0 && (
+            <TouchableOpacity
+              className="mb-4 flex-row items-center"
+              onPress={() =>
+                router.push(`/(app)/participants?eventId=${event.id}`)
+              }
+              activeOpacity={0.7}
+            >
+              <View
+                style={{
+                  width:
+                    AVATAR_SIZE +
+                    (avatarStack.length - 1) * (AVATAR_SIZE - AVATAR_OVERLAP),
+                  height: AVATAR_SIZE,
+                  position: "relative",
+                  marginRight: 10,
+                }}
+              >
+                {avatarStack.map((p, i) => {
+                  const initials = (
+                    p.profile?.display_name ||
+                    p.profile?.email?.split("@")[0] ||
+                    "?"
+                  ).trim().slice(0, 1).toUpperCase();
+                  return (
+                    <View
+                      key={p.user_id}
+                      style={{
+                        position: "absolute",
+                        left: i * (AVATAR_SIZE - AVATAR_OVERLAP),
+                        width: AVATAR_SIZE,
+                        height: AVATAR_SIZE,
+                        borderRadius: AVATAR_SIZE / 2,
+                        borderWidth: 2,
+                        borderColor: "#FFFFFF",
+                        overflow: "hidden",
+                        backgroundColor: "#BB0000",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        zIndex: avatarStack.length - i,
+                      }}
+                    >
+                      {p.profile?.avatar_url ? (
+                        <Image
+                          source={{ uri: p.profile.avatar_url }}
+                          style={{
+                            width: AVATAR_SIZE,
+                            height: AVATAR_SIZE,
+                          }}
+                        />
+                      ) : (
+                        <Text
+                          style={{
+                            color: "#FFFFFF",
+                            fontSize: 13,
+                            fontWeight: "700",
+                          }}
+                        >
+                          {initials}
+                        </Text>
+                      )}
+                    </View>
+                  );
+                })}
+              </View>
+              <Text className="text-osu-dark text-sm flex-1">{joinSummary}</Text>
+            </TouchableOpacity>
+          )}
 
           {event.description && (
             <View className="mb-4">

--- a/apps/mobile/app/(app)/participants.tsx
+++ b/apps/mobile/app/(app)/participants.tsx
@@ -1,0 +1,91 @@
+import { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  Image,
+  ActivityIndicator,
+  TouchableOpacity,
+} from "react-native";
+import { useLocalSearchParams, router } from "expo-router";
+import { supabase } from "../../lib/supabase";
+import type { EventParticipant } from "shared";
+
+export default function ParticipantsScreen() {
+  const { eventId } = useLocalSearchParams<{ eventId: string }>();
+  const [participants, setParticipants] = useState<EventParticipant[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!eventId) return;
+
+    const fetchParticipants = async () => {
+      const { data, error } = await (supabase
+        .from("event_members")
+        .select(
+          "user_id, profile:profiles!event_members_user_id_fkey(id, email, display_name, avatar_url)",
+        )
+        .eq("event_id", eventId) as any);
+
+      if (!error) {
+        setParticipants((data as EventParticipant[]) ?? []);
+      }
+      setLoading(false);
+    };
+
+    fetchParticipants();
+  }, [eventId]);
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-osu-light items-center justify-center">
+        <ActivityIndicator size="large" color="#BB0000" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-osu-light">
+      <View className="p-4 gap-2">
+        {participants.length === 0 ? (
+          <Text className="text-gray-500 text-center mt-8">
+            No participants yet
+          </Text>
+        ) : (
+          participants.map((p) => {
+            const displayName =
+              p.profile?.display_name ||
+              p.profile?.email?.split("@")[0] ||
+              "Unknown";
+            const initials = displayName.trim().slice(0, 1).toUpperCase();
+            return (
+              <TouchableOpacity
+                key={p.user_id}
+                className="flex-row items-center bg-white rounded-xl px-4 py-3"
+                style={{ shadowColor: "#000", shadowOpacity: 0.04, shadowRadius: 4, elevation: 1 }}
+                onPress={() => router.push(`/(app)/profile/${p.user_id}`)}
+                activeOpacity={0.7}
+              >
+                {p.profile?.avatar_url ? (
+                  <Image
+                    source={{ uri: p.profile.avatar_url }}
+                    className="w-10 h-10 rounded-full"
+                  />
+                ) : (
+                  <View className="w-10 h-10 rounded-full bg-osu-scarlet items-center justify-center">
+                    <Text className="text-white font-bold text-base">
+                      {initials}
+                    </Text>
+                  </View>
+                )}
+                <Text className="ml-3 text-osu-dark font-medium text-base">
+                  {displayName}
+                </Text>
+              </TouchableOpacity>
+            );
+          })
+        )}
+      </View>
+    </ScrollView>
+  );
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -41,10 +41,16 @@ export interface Feedback {
 }
 
 // Extended types for UI
+export interface EventParticipant {
+  user_id: string;
+  profile: Pick<Profile, "id" | "email" | "display_name" | "avatar_url"> | null;
+}
+
 export interface EventWithDetails extends Event {
   host?: Profile;
   attendee_count?: number;
   is_joined?: boolean;
+  participants?: EventParticipant[];
 }
 
 // Form types


### PR DESCRIPTION
#30 

Display an overlapping avatar stack (up to 5) and a join summary (Alex, and 2 others joined) on the event detail screen. Tapping opens a new Participants screen listing all attendees with their profile photos and names. Falls back to email prefix when display name is null.